### PR TITLE
Android 28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN dpkg --add-architecture i386 && \
 
     # Installs Android SDK
     mkdir android && cd android && \
-    wget --non-verbose -O tools.zip ${ANDROID_SDK_URL} && \
+    wget --no-verbose -O tools.zip ${ANDROID_SDK_URL} && \
     unzip tools.zip && rm tools.zip && \
     (echo y; echo y; echo y; echo y; echo y; echo y) | android update sdk -a -u -t platform-tools,${ANDROID_APIS},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
     chmod a+x -R $ANDROID_HOME && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Lee Meador <docker@leemeador.com>
 
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" \
     ANDROID_BUILD_TOOLS_VERSION=29.0.0 \
-    ANDROID_APIS="android-25,android-26,android-27" \
+    ANDROID_APIS="android-26,android-27,android-28" \
     ANT_HOME="/usr/share/ant" \
     MAVEN_HOME="/usr/share/maven" \
     GRADLE_HOME="/usr/share/gradle" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM beevelop/java
 
-MAINTAINER Maik Hummel <m@ikhummel.com>
+MAINTAINER Lee Meador <docker@leemeador.com>
 
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" \
-    ANDROID_BUILD_TOOLS_VERSION=27.0.0 \
-    ANDROID_APIS="android-10,android-15,android-16,android-17,android-18,android-19,android-20,android-21,android-22,android-23,android-24,android-25,android-26" \
+    ANDROID_BUILD_TOOLS_VERSION=29.0.0 \
+    ANDROID_APIS="android-25,android-26,android-27" \
     ANT_HOME="/usr/share/ant" \
     MAVEN_HOME="/usr/share/maven" \
     GRADLE_HOME="/usr/share/gradle" \
-    ANDROID_HOME="/opt/android"
+    ANDROID_HOME="/opt/android" \
+    ANDROID_SDK_ROOT="/opt/android"
 
 ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$ANT_HOME/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin
 
@@ -17,6 +18,7 @@ WORKDIR /opt
 RUN dpkg --add-architecture i386 && \
     apt-get -qq update && \
     apt-get -qq install -y wget curl maven ant gradle libncurses5:i386 libstdc++6:i386 zlib1g:i386 && \
+    apt-get -qq install -y sudo bzip2 ca-certificates && \
 
     # Installs Android SDK
     mkdir android && cd android && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,12 @@ MAINTAINER Lee Meador <docker@leemeador.com>
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip" \
     ANDROID_BUILD_TOOLS_VERSION=29.0.0 \
     ANDROID_APIS="android-26,android-27,android-28" \
-    ANT_HOME="/usr/share/ant" \
     MAVEN_HOME="/usr/share/maven" \
     GRADLE_HOME="/usr/share/gradle" \
     ANDROID_HOME="/opt/android" \
     ANDROID_SDK_ROOT="/opt/android"
 
-ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$ANT_HOME/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin
+ENV PATH $PATH:$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$ANDROID_BUILD_TOOLS_VERSION:$ANDROID_HOME/tools/bin:$MAVEN_HOME/bin:$GRADLE_HOME/bin
 
 WORKDIR /opt
 
@@ -24,7 +23,9 @@ RUN dpkg --add-architecture i386 && \
     mkdir android && cd android && \
     wget --no-verbose -O tools.zip ${ANDROID_SDK_URL} && \
     unzip tools.zip && rm tools.zip && \
-    (echo y; echo y; echo y; echo y; echo y; echo y) | android update sdk -a -u -t platform-tools,${ANDROID_APIS},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
+    (echo y; echo y; echo y; echo y; echo y; echo y) | \
+        android update sdk -a -u -t platform-tools,${ANDROID_APIS},build-tools-${ANDROID_BUILD_TOOLS_VERSION} | \
+        grep -v "Unzipping" | grep -v "Downloading" && \
     chmod a+x -R $ANDROID_HOME && \
     chown -R root:root $ANDROID_HOME && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,9 @@ RUN dpkg --add-architecture i386 && \
 
     # Installs Android SDK
     mkdir android && cd android && \
-    wget -O tools.zip ${ANDROID_SDK_URL} && \
+    wget --non-verbose -O tools.zip ${ANDROID_SDK_URL} && \
     unzip tools.zip && rm tools.zip && \
-    echo y | android update sdk -a -u -t platform-tools,${ANDROID_APIS},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
+    (echo y; echo y; echo y; echo y; echo y; echo y) | android update sdk -a -u -t platform-tools,${ANDROID_APIS},build-tools-${ANDROID_BUILD_TOOLS_VERSION} && \
     chmod a+x -R $ANDROID_HOME && \
     chown -R root:root $ANDROID_HOME && \
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /opt
 
 RUN dpkg --add-architecture i386 && \
     apt-get -qq update && \
-    apt-get -qq install -y wget curl maven ant gradle libncurses5:i386 libstdc++6:i386 zlib1g:i386 && \
+    apt-get -qq install -y wget curl maven gradle libncurses5:i386 libstdc++6:i386 zlib1g:i386 && \
     apt-get -qq install -y sudo bzip2 ca-certificates && \
 
     # Installs Android SDK

--- a/README.md
+++ b/README.md
@@ -1,44 +1,33 @@
-[![Travis](https://shields.beevelop.com/travis/beevelop/docker-android.svg?style=flat-square)](https://travis-ci.org/beevelop/docker-android)
-[![Docker Pulls](https://shields.beevelop.com/docker/pulls/beevelop/android.svg?style=flat-square)](https://links.beevelop.com/d-android)
-[![Layers](https://shields.beevelop.com/docker/image/layers/beevelop/android/latest.svg?style=flat-square)](https://links.beevelop.com/d-android)
-[![Size](https://shields.beevelop.com/docker/image/size/beevelop/android/latest.svg?style=flat-square)](https://links.beevelop.com/d-android)
-[![GitHub release](https://shields.beevelop.com/github/release/beevelop/docker-android.svg?style=flat-square)](https://github.com/beevelop/docker-android/releases)
-![Badges](https://shields.beevelop.com/badge/badges-7-brightgreen.svg?style=flat-square)
-[![Beevelop](https://links.beevelop.com/honey-badge)](https://beevelop.com)
 
-# Android 7 (SDK 25.X)
+# Android 26-28 (SDK 29.X)
 ### based on [beevelop/java](https://github.com/beevelop/docker-java)
 - Ant 1.9.6
 - Maven 3.3.9
 - Java 1.8.0_111
 - Gradle 2.10 (Groovy 2.4.5)
-- Android SDK 24.4.1
-    + APIs: android-10,android-15,android-16,android-17,android-18,android-19,android-20,android-21,android-22,android-23,android-24,android-25
-    + Build-Tools: 25.0.2
+- Android SDK
+    + APIs: android-26,android-27,android-28
+    + Build-Tools: 29.0.0
 
-----
-## Tagging scheme
-- `v${TOOLS_VERSION}-${BUILD_TOOLS_VERSION}-${HIGHEST_ANDROID_SDK_VERSION}`
-- e.g. `v25.2.5-27.0.0-26`
 ----
 ### Pull from Docker Hub
 ```
-docker pull beevelop/android:latest
+docker pull leemeador/android:latest
 ```
 
 ### Build from GitHub
 ```
-docker build -t beevelop/android github.com/beevelop/docker-android
+docker build -t leemeador/android github.com/leemeador/docker-android
 ```
 
 ### Run image
 ```
-docker run -it beevelop/android bash
+docker run -it leemeador/android bash
 ```
 
 ### Use as base image
 ```Dockerfile
-FROM beevelop/android:latest
+FROM leemeador/android:latest
 ```
 
 ----


### PR DESCRIPTION
Use only 3 consecutive Android versions ending in 28, remove ant

DO NOT DELETE THIS BRANCH 

as dockerhub is configured to build master and android-xx branches to create images using LATEST and xx versions, respectively. Merging to master will update latest to this one.